### PR TITLE
Added command line arguments for signing with an android keystore

### DIFF
--- a/Unity/MobileBuildRunner.cs
+++ b/Unity/MobileBuildRunner.cs
@@ -153,6 +153,11 @@ public class MobileBuildRunner
 	{
 		return CommandLineReader.GetCustomArgument("keyAliasPass");
 	}
+    
+    private static string ReadBundleIdentifier()
+	{
+		return CommandLineReader.GetCustomArgument("bundleIdentifier");
+	}
 
 	class BuildRequest
 	{
@@ -164,6 +169,12 @@ public class MobileBuildRunner
 		{
 			if (BuildPipeline.isBuildingPlayer)
 				return;
+            
+            string bundleIdentifier = ReadBundleIdentifier();
+            if (bundleIdentifier != null) {
+                PlayerSettings.bundleIdentifier = bundleIdentifier;
+            }
+            
 			Debug.Log (DateTime.Now.ToString() + ": Build " + this.ToString());
 			EditorUserBuildSettings.SwitchActiveBuildTarget (TargetPlatform);
 			AssetDatabase.Refresh();

--- a/Unity/MobileBuildRunner.cs
+++ b/Unity/MobileBuildRunner.cs
@@ -38,6 +38,26 @@ public class MobileBuildRunner
 			Directory.CreateDirectory(DEFAULT_BUILD_DIR);
 			output = DEFAULT_ANDROID_APK_FILE;
 		}
+        
+        string keystoreName = ReadKeystoreName ();
+		if (keystoreName != null) {
+			PlayerSettings.Android.keystoreName = keystoreName;
+		}
+
+		string keystorePass = ReadKeystorePass ();
+		if (keystorePass != null) {
+			PlayerSettings.Android.keystorePass = keystorePass;
+		}
+
+		string keyAliasName = ReadKeyAliasName ();
+		if (keystorePass != null) {
+			PlayerSettings.Android.keyaliasName = keyAliasName;
+		}
+
+		string keyAliasPass = ReadKeyAliasPass ();
+		if (keystorePass != null) {
+			PlayerSettings.Android.keyaliasPass = keyAliasPass;
+		}
 
 		new BuildRequest {
 			Output = output,
@@ -112,6 +132,26 @@ public class MobileBuildRunner
 	private static string ReadTargetOutputPath()
 	{
 		return CommandLineReader.GetCustomArgument("outputPath");
+	}
+    
+    private static string ReadKeystoreName()
+	{
+		return CommandLineReader.GetCustomArgument("keystoreName");
+	}
+
+	private static string ReadKeystorePass()
+	{
+		return CommandLineReader.GetCustomArgument("keystorePass");
+	}
+
+	private static string ReadKeyAliasName()
+	{
+		return CommandLineReader.GetCustomArgument("keyAliasName");
+	}
+
+	private static string ReadKeyAliasPass()
+	{
+		return CommandLineReader.GetCustomArgument("keyAliasPass");
 	}
 
 	class BuildRequest

--- a/Unity/MobileBuildRunner.cs
+++ b/Unity/MobileBuildRunner.cs
@@ -50,12 +50,12 @@ public class MobileBuildRunner
 		}
 
 		string keyAliasName = ReadKeyAliasName ();
-		if (keystorePass != null) {
+		if (keyAliasName != null) {
 			PlayerSettings.Android.keyaliasName = keyAliasName;
 		}
 
 		string keyAliasPass = ReadKeyAliasPass ();
-		if (keystorePass != null) {
+		if (keyAliasPass != null) {
 			PlayerSettings.Android.keyaliasPass = keyAliasPass;
 		}
 


### PR DESCRIPTION
Command line arguments must be prepended by "**-gj.mobilebuild:**" followed by the actual arguments separated by a '**;**'.

**Added Arguments:**
keystoreName
keystorePass
keyAliasName
keyAliasPass

**Preexisting Arguments:**
outputPath

**EXAMPLE:**
-projectPath "${WORKSPACE}/${ProjectDirectory}" -quit -batchmode -nographics -buildTarget android -logFile "${WORKSPACE}/build.log" -executeMethod MobileBuildRunner.PerformAndroidBuild -gj.mobilebuild:outputPath="${WORKSPACE}/app.apk”;keystorePass=“${KEYSTOREPASS}”;keystoreName="${KEYSTORENAME}";keyAliasName=“${KEYALIASNAME}”;keyAliasPass=“${KEYALIASPASS}”
